### PR TITLE
feat(type): added type definition file

### DIFF
--- a/d8-jsonapi-querystring.d.ts
+++ b/d8-jsonapi-querystring.d.ts
@@ -1,6 +1,7 @@
 
 declare module "d8-jsonapi-querystring" {
     interface jsonApiRequestObject {
+        sortCreated?: any,
         sort?: any,
         fields?: any,
         include?: string[],

--- a/d8-jsonapi-querystring.d.ts
+++ b/d8-jsonapi-querystring.d.ts
@@ -1,0 +1,12 @@
+
+declare module "d8-jsonapi-querystring" {
+    interface jsonApiRequestObject {
+        sort?: any,
+        fields?: any,
+        include?: string[],
+        filter?: any,
+        page?: any,
+    }
+    function buildQueryString(object: jsonApiRequestObject, stackedPath?: string, stringsParts?: any[]): string;
+    export { jsonApiRequestObject, buildQueryString };
+}

--- a/d8-jsonapi-querystring.d.ts
+++ b/d8-jsonapi-querystring.d.ts
@@ -1,7 +1,6 @@
 
 declare module "d8-jsonapi-querystring" {
     interface jsonApiRequestObject {
-        sortCreated?: any,
         sort?: any,
         fields?: any,
         include?: string[],

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.3",
   "description": "Create a Drupal 8 JSON API query string from a nested object",
   "main": "index.js",
+  "typings": "d8-jsonapi-querystring.d.ts",
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
This PR ads a type definition file for the package. By including it in the package.json file as the "typings" it will be automatically detected on typescript projects and people dont have to install it via https://www.npmjs.com/~types which is super practical.

it ads a simple definition for of course the function and its parameters but also for the Object that the function receives as the Object to transform into the request.

*  ? in front of a key means its optional
*  string[] is an array of strings

Let me know what you think about it. I have tried it in the angular contenta app and works nicely. also automatically autosuggests keys as you start building the object.

![screen shot 2017-06-30 at 21 38 39](https://user-images.githubusercontent.com/2866604/27753524-e92c9c6a-5ddd-11e7-9574-9316e85c3ebc.png)

